### PR TITLE
Update the disk watermark limits for ES to 95%

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
+      - cluster.routing.allocation.disk.watermark.high=95%
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:


### PR DESCRIPTION
This avoids ES getting stuck when server is low on disk space