### PR TITLE
fix: upgrade filebeat and update filebeat configuration

### DIFF
--- a/configs/filebeat/config.yml
+++ b/configs/filebeat/config.yml
@@ -2,40 +2,12 @@ filebeat.autodiscover:
   providers:
     - type: docker
       hints.enabled: true
-      templates:
-        - conditions:
-            contains:
-              docker.container.image: nginx
-          config:
-            - module: nginx
-              access:
-                enabled: true
-                input:
-                  type: docker
-                  containers:
-                    ids: "${data.docker.container.id}"
-                    stream: "stdout"
-              error:
-                enabled: true
-                input:
-                  type: docker
-                  containers:
-                    ids: "${data.docker.container.id}"
-                    stream: "stderr"
-
-# filebeat.inputs:
-# - type: container
-#   paths: 
-#     - '/var/lib/docker/containers/*/*.log'
-
-# processors:
-# - add_docker_metadata:
-#     host: "unix:///var/run/docker.sock"
-
-# - decode_json_fields:
-#     fields: ["message"]
-#     target: "json"
-#     overwrite_keys: true
+      co.elastic.logs/module: nginx
+      co.elastic.logs/fileset.stdout: access
+      co.elastic.logs/fileset.stderr: error
+      co.elastic.logs/json.keys_under_root: true
+      co.elastic.logs/json.add_error_key: true
+      co.elastic.logs/json.message_key: log
 
 processors:
 - add_docker_metadata:

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -6,10 +6,10 @@ services:
   filebeat:
     # filebeat pushes logs to elasticsearch monitoring
     restart: always
-    image: elastic/filebeat:7.2.0
+    image: elastic/filebeat:7.17.9
     user: "root"
     privileged: true
-    command: ["--strict.perms=false"]
+    command: [ "--strict.perms=false" ]
     environment:
       - ELASTICSEARCH_HOSTS
     volumes:


### PR DESCRIPTION
Logs were not saved on [Kibana](https://kibana.openfoodfacts.org) since November 2022. After investigation, it turns out two errors were regularly output by filebeat that prevented the logs to be stored in Elasticsearch:

- ERROR [reload] cfgfile/list.go:99 Error creating runner from config: failed to create input: Can only start an input when all related states are finished
- ES: only write ops with an op_type of create are allowed in data streams

It was difficult to know the cause of the error, but the filebeat version used was old (4 years old), so I tried to upgrade filebeat and update the filebeat configuration accordingly.
It solved the issues.

This configuration was tested in staging and in prod.
Furthermore, 2 filebeat services were running concurrently (`monitoring_filebeat_1` and `filebeat_filebeat_1`). It looks like the docker project was renamed without the old service being shutdown.