### PR TITLE
fix: change filebeat logs pattern

### DIFF
--- a/configs/filebeat/config.yml
+++ b/configs/filebeat/config.yml
@@ -20,7 +20,7 @@ processors:
 output.elasticsearch:
   hosts: ["${ELASTICSEARCH_HOSTS}"]
   indices:
-    - index: "logs-%{+yyyy.MM.dd}"
+    - index: "logs-%{+yyyy-MM-dd}"
 
 filebeat.config.modules.path: /usr/share/filebeat/modules.d/*.yml
 


### PR DESCRIPTION
### What
Current logs pattern, does not enable applying a rollover lifecycle policy (while we need it) because a rollover logs must match the pattern `^.*-\d+`.

Part of:
- https://github.com/openfoodfacts/openfoodfacts-infrastructure/issues/199