### PR TITLE
feat: add elasticsearch exporters

### DIFF
--- a/configs/prometheus/config.yml
+++ b/configs/prometheus/config.yml
@@ -101,6 +101,19 @@ scrape_configs:
           service: postgres
           env: net
 
+  - job_name: docker-elasticsearch
+    static_configs:
+      - targets: ["10.1.0.200:9114"]
+        labels:
+          app: search-a-licious
+          service: elasticsearch
+          env: net
+      - targets: ["10.1.0.201:9114"]
+        labels:
+          app: search-a-licious
+          service: elasticsearch
+          env: org
+
   - job_name: mysqld
     static_configs:
       - targets: ["10.1.0.107:9104"]


### PR DESCRIPTION
Fetch Prometheus metrics from search-a-licious ES exporters.