### PR TITLE
feat: add off apache-priority monitoring

### DIFF
--- a/configs/prometheus/config.yml
+++ b/configs/prometheus/config.yml
@@ -156,6 +156,7 @@ scrape_configs:
         - proxy/nginx
         - off/nginx
         - off/apache
+        - off/apache-priority
         labels:
           app: off
           env: prod


### PR DESCRIPTION
We have a new apache@priority instance on off, monitor it.