### PR TITLE
ci: Move monitoring to the new `monitoring-01` VM

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -19,8 +19,8 @@ jobs:
       run: |
         # direct container access
         # deploy target
-        echo "SSH_HOST=10.1.0.203" >> $GITHUB_ENV
-        echo "SSH_PROXY_HOST=ovh1.openfoodfacts.org" >> $GITHUB_ENV
+        echo "SSH_HOST=34.1.5.157" >> $GITHUB_ENV # monitoring-01
+        echo "SSH_PROXY_HOST=" >> $GITHUB_ENV # no proxy
         echo "SSH_USERNAME=off" >> $GITHUB_ENV
         # did only config change ? (in this case we only need a restart)
         declare current_branch=$(git rev-parse --abbrev-ref HEAD)

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -48,10 +48,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         script_stop: false
         script: |
           echo "RESTART_ONLY is ${{ env.RESTART_ONLY }}"
@@ -70,10 +70,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         script_stop: false
         script: |
           # Go to repository directory
@@ -110,10 +110,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         script_stop: false
         script: |
           cd monitoring/
@@ -125,10 +125,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         script_stop: false
         script: |
           cd monitoring/
@@ -140,10 +140,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         script_stop: false
         script: |
           cd monitoring/
@@ -157,10 +157,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         script_stop: false
         script: |
           cd monitoring/
@@ -172,10 +172,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         script_stop: false
         script: |
           cd monitoring/
@@ -187,10 +187,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets.SSH_PRIVATE_KEY_MONITORING_01 }}
         script_stop: false
         script: |
           cd monitoring/

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - deploy-*
+      - deploy-container-*
 
 jobs:
   deploy:

--- a/.github/workflows/filebeat-deploy.yml
+++ b/.github/workflows/filebeat-deploy.yml
@@ -17,22 +17,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        host:
+        server:
           # dockers
-          - "10.1.0.200"
+          - host: "10.1.0.200"
+            proxy: "ovh1.openfoodfacts.org"
           # prod dockers
-          - "10.1.0.201"
-          # monitoring
-          - "10.1.0.203"
+          - host: "10.1.0.201"
+            proxy: "ovh1.openfoodfacts.org"
+          # monitoring-01
+          - host: "34.1.5.157"
+            proxy: "" # no proxy
     steps:
     - name: Set env variables
       run: |
         # direct container access
         # deploy target
-        echo "SSH_HOST=${{ matrix.host }}" >> $GITHUB_ENV
-        echo "SSH_PROXY_HOST=ovh1.openfoodfacts.org" >> $GITHUB_ENV
+        echo "SSH_HOST=${{ matrix.server.host }}" >> $GITHUB_ENV
+        echo "SSH_PROXY_HOST=${{ matrix.server.proxy }}" >> $GITHUB_ENV
         echo "SSH_USERNAME=off" >> $GITHUB_ENV
-        echo "MONITORING_HOST=10.1.0.203" >> $GITHUB_ENV
+        echo "MONITORING_HOST=34.1.5.157" >> $GITHUB_ENV # monitoring-01
     - name: Checkout git repository
       uses: appleboy/ssh-action@master
       with:

--- a/.github/workflows/filebeat-deploy.yml
+++ b/.github/workflows/filebeat-deploy.yml
@@ -21,12 +21,15 @@ jobs:
           # dockers
           - host: "10.1.0.200"
             proxy: "ovh1.openfoodfacts.org"
+            ssh_key_name: "SSH_PRIVATE_KEY_OVH1"
           # prod dockers
           - host: "10.1.0.201"
             proxy: "ovh1.openfoodfacts.org"
+            ssh_key_name: "SSH_PRIVATE_KEY_OVH1"
           # monitoring-01
           - host: "34.1.5.157"
             proxy: "" # no proxy
+            ssh_key_name: "SSH_PRIVATE_KEY_MONITORING_01"
     steps:
     - name: Set env variables
       run: |
@@ -41,10 +44,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets[matrix.server.ssh_key_name] }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets[matrix.server.ssh_key_name] }}
         script_stop: false
         script: |
           # Clone Git repository if not already there
@@ -68,10 +71,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets[matrix.server.ssh_key_name] }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets[matrix.server.ssh_key_name] }}
         script_stop: false
         script: |
           # Go to repository directory
@@ -95,10 +98,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets[matrix.server.ssh_key_name] }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets[matrix.server.ssh_key_name] }}
         script_stop: false
         script: |
           cd filebeat/
@@ -110,10 +113,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets[matrix.server.ssh_key_name] }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets[matrix.server.ssh_key_name] }}
         script_stop: false
         script: |
           cd filebeat/
@@ -125,10 +128,10 @@ jobs:
       with:
         host: ${{ env.SSH_HOST }}
         username: ${{ env.SSH_USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        key: ${{ secrets[matrix.server.ssh_key_name] }}
         proxy_host: ${{ env.SSH_PROXY_HOST }}
         proxy_username: ${{ env.SSH_USERNAME }}
-        proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        proxy_key: ${{ secrets[matrix.server.ssh_key_name] }}
         script_stop: false
         script: |
           cd filebeat/

--- a/.github/workflows/filebeat-deploy.yml
+++ b/.github/workflows/filebeat-deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - deploy-*
+      - deploy-filebeat-*
     paths-ignore:
       - configs/alertmanager/**
       - configs/blackbox_exporter/**

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ log:
 # Production #
 #------------#
 
+# Create external networks (useful in dev)
+create_external_networks:
+	docker network create reverse_proxy_network
 # Create all external volumes needed for production. Using external volumes is useful to prevent data loss (as they are not deleted when performing docker down -v)
 create_external_volumes:
 	docker volume create ${COMPOSE_PROJECT_NAME}_influxdb-data

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ NFS_VOLUMES_BASE_PATH ?= /rpool/backups/monitoring-volumes/
 #----------------#
 # Docker Compose #
 #----------------#
-dev: replace_env build up
+dev: replace_env build create_external_networks up
 
 build:
 	@echo "🥫 Building containers …"
@@ -65,7 +65,7 @@ log:
 
 # Create external networks (useful in dev)
 create_external_networks:
-	docker network create reverse_proxy_network
+	docker network create reverse_proxy_network || true
 # Create all external volumes needed for production. Using external volumes is useful to prevent data loss (as they are not deleted when performing docker down -v)
 create_external_volumes:
 	docker volume create ${COMPOSE_PROJECT_NAME}_influxdb-data

--- a/configs/prometheus/config.yml
+++ b/configs/prometheus/config.yml
@@ -13,30 +13,94 @@ alerting:
         - targets: ["alertmanager:9093"]
 
 scrape_configs:
-  - job_name: docker-cadvisor
+  # OVH promox cluster exporters
+  # They are exposed on the reverse proxy at ovh-exporters.openfoodfacts.org
+  # this rule enable to get them
+  - job_name: ovh-exporters
+    scheme: https
+    basic_auth:
+      username: prometheus
+      password_file: /etc/prometheus/secrets/ovh.txt
     static_configs:
-      - targets: ["10.1.0.203:8280"]
+      - targets:
+          # those must follow job/env/app/service
+          # corresponding url is https://ovh-exporters.openfoodfacts.org/job/env/app/service/metrics
+        - "docker-cadvisor/net/docker/cadvisor"
+        - "docker-prod/org/docker/cadvisor"
+          # node exporter
+        - "node-exporter/net/system/vm"
+        - "node-exporter/org/system/vm"
+          # docker nginx
+        - "docker-nginx/net/off/frontend"
+          # docker apache
+        - "docker-apache/net/off/backend"
+          # docker-statsd (for robotoff gunicorn)
+        - "docker-statsd/net/robotoff/api"
+          # moved to moji "docker-statsd/org/robotoff/api" 10.1.0.201:9102;
+          # docker-postgres
+        - "docker-postgres/net/robotoff/postgres"
+          # moved to moji - "docker-postgres/org/robotoff/postgres" 10.1.0.201:9187;
+          # Proxmox gateway postfix
+        - "pmg-postfix/prod/pmg/postfix"
+          # docker-elasticsearch
+        - "docker-elasticsearch/net/search-a-licious/elasticsearch"
+        - "docker-elasticsearch/org/search-a-licious/elasticsearch"
+          # matomo mysqld
+        - "mysqld/prod/matomo/mysqld"
+          # matomo nginx
+        - "mysqld/prod/matomo/nginx"
         labels:
-          env: monitoring
-      - targets: ["10.1.0.201:8280"]
-        labels:
-          env: org
-      - targets: ["10.1.0.200:8280"]
-        labels:
-          env: net
+          base_url: ovh-exporters.openfoodfacts.org:443
+          metrics_path: metrics
+    relabel_configs: &ovh_exporters_relabel_config
+      # get job name, first part
+      - source_labels: [__address__]
+        regex: ^([^/]+)/.*$
+        replacement: ${1}
+        target_label: job
+      # get env, second part
+      - source_labels: [__address__]
+        regex: ^[^/]+/([^/]+)/.*$
+        replacement: ${1}
+        target_label: env
+      # get app, third part
+      - source_labels: [__address__]
+        regex: ^[^/]+/[^/]+/([^/]+)/.*$
+        replacement: ${1}
+        target_label: app
+      # get service, fourth part
+      - source_labels: [__address__]
+        regex: ^[^/]+/[^/]+/[^/]+/([^/]+)$
+        replacement: ${1}
+        target_label: service
+      # the metrics path is adress + /metrics
+      - source_labels: [__address__, metrics_path]
+        separator: /
+        target_label: __metrics_path__
+      # put base url as address, as it is the same for all
+      - source_labels: [base_url]
+        target_label: __address__
+      # drop labels that where only useful for configuration
+      - regex: ^(base_url|metrics_path)$
+        action: labeldrop
 
-  - job_name: docker-node-exporter
+  # local jobs, on the same host
+  - job_name: monitoring-exporters
     static_configs:
-      - targets: ["10.1.0.203:8281"]
+      - targets: ["host.docker.internal:8280"]
         labels:
+          job: docker-cadvisor
+          app: docker
           env: monitoring
-      - targets: ["10.1.0.201:8281"]
+          service: cadvisor
+      - targets: ["host.docker.internal:8281"]
         labels:
-          env: org
-      - targets: ["10.1.0.200:8281"]
-        labels:
-          env: net
+          job: node-exporter
+          app: system
+          env: monitoring
+          service: vm
 
+  # local jobs in the same docker network
   # TODO: use Docker Service Discovery https://prometheus.io/docs/prometheus/latest/configuration/configuration/#docker_sd_config
   - job_name: docker-containers
     sample_limit: 50000
@@ -59,87 +123,7 @@ scrape_configs:
           app: blackbox_exporter
           env: org
 
-  - job_name: docker-nginx
-    static_configs:
-      - targets: ["10.1.0.200:9113"]
-        labels:
-          app: off
-          service: frontend
-          env: net
-
-  - job_name: docker-apache
-    static_configs:
-      - targets: ["10.1.0.200:9117"]
-        labels:
-          app: off
-          service: backend
-          env: net
-
-  - job_name: docker-statsd
-    static_configs:
-      - targets: ["10.1.0.200:9102"]
-        labels:
-          app: robotoff
-          service: api
-          env: net
-      - targets: ["10.1.0.201:9102"]
-        labels:
-          app: robotoff
-          service: api
-          env: org
-
-  - job_name: docker-postgres
-    static_configs:
-      - targets: ["10.1.0.201:9187"]
-        labels:
-          app: robotoff
-          service: postgres
-          env: org
-      - targets: ["10.1.0.200:9187"]
-        labels:
-          app: robotoff
-          service: postgres
-          env: net
-
-  - job_name: pmg-postfix
-    static_configs:
-      - targets:
-        # PMG
-        - "10.1.0.102:9154"
-        labels:
-          app: Proxmox mail gateway
-          service: postfix
-          env: prod
-
-  - job_name: docker-elasticsearch
-    static_configs:
-      - targets: ["10.1.0.200:9114"]
-        labels:
-          app: search-a-licious
-          service: elasticsearch
-          env: net
-      - targets: ["10.1.0.201:9114"]
-        labels:
-          app: search-a-licious
-          service: elasticsearch
-          env: org
-
-  - job_name: mysqld
-    static_configs:
-      - targets: ["10.1.0.107:9104"]
-        labels:
-          app: matomo
-          service: mysqld
-          env: prod
-
-  - job_name: nginx
-    static_configs:
-      - targets: ["10.1.0.107:9113"]
-        labels:
-          app: matomo
-          service: nginx
-          env: prod
-
+  # Free promox cluster Exporters
   # NGINX is proxying the exporters of servers at free
   # this rule enable to get them
   - job_name: free-exporters

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   influxdb:
     restart: always
@@ -119,6 +117,9 @@ services:
     networks:
       - monitoring
       - reverse_proxy_network # using port 9090
+    # enable reaching host internal ip
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   blackbox_exporter:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,20 +29,18 @@ services:
       - ./configs/grafana/:/etc/grafana/provisioning
       - ./configs/grafana/config.ini:/usr/share/grafana/conf/defaults.ini
       - grafana-data:/var/lib/grafana
-    ports:
-      - 3000:3000
     networks:
       - monitoring
+      - reverse_proxy_network # using port 3000
 
   kibana:
     restart: always
     image: kibana:7.14.2
-    ports:
-      - 5601:5601
     volumes:
       - ./configs/kibana/kibana.yml:/home/kibana/config/kibana.yml
     networks:
       - monitoring
+      - reverse_proxy_network # using port 5601
 
   # elasticsearch-datagen:
   #   image: oliver006/es-test-data
@@ -94,8 +92,6 @@ services:
   alertmanager:
     restart: always
     image: prom/alertmanager:v0.23.0
-    ports:
-      - 9093:9093
     volumes:
       - alertmanager-data:/var/lib/prometheus/alertmanager
       - ./configs/alertmanager/:/etc/alertmanager/
@@ -105,6 +101,7 @@ services:
       - '--web.external-url=https://alertmanager.openfoodfacts.org/'
     networks:
       - monitoring
+      - reverse_proxy_network # using port 9093
 
   prometheus:
     restart: always
@@ -119,10 +116,9 @@ services:
       - '--web.console.templates=/usr/share/prometheus/consoles'
       - '--web.external-url=https://prometheus.openfoodfacts.org/'
       - '--web.enable-admin-api'
-    ports:
-      - 9090:9090
     networks:
       - monitoring
+      - reverse_proxy_network # using port 9090
 
   blackbox_exporter:
     restart: always
@@ -143,5 +139,8 @@ volumes:
   elasticsearch-backup:
   prometheus-data:
   alertmanager-data:
+
 networks:
   monitoring:
+  reverse_proxy_network:
+    external: true


### PR DESCRIPTION
### What

Work in progress to move the monitoring from `ovh1` to `monitoring-01`

- [x] Update the CI/CD to deploy to `monitoring-01`
- [ ]  Update the configs of the monitoring tools
    - [ ]  [configs/prometheus/config.yml](https://github.com/openfoodfacts/openfoodfacts-monitoring/blob/main/configs/prometheus/config.yml) references the old IP of the monitoring server (`10.1.0.203`)
    - [x] For `monitoring-01` host, Update [docker-compose.yml](https://github.com/openfoodfacts/openfoodfacts-monitoring/blob/main/docker-compose.yml) to use `reverse_proxy_network` and to not open unnecessary ports.
    - [ ] For exporter hosts, maybe we should do something to avoid exposing all necessary endpoints to internet. Like a nginx proxy ?
- [x] Add `SSH_PRIVATE_KEY_MONITORING_01` and `SSH_PRIVATE_KEY_OVH1` secrets. `SSH_PRIVATE_KEY_OVH1` is what is currently `SSH_PRIVATE_KEY` .

### Related with

- https://github.com/openfoodfacts/openfoodfacts-infrastructure/pull/474

