### PR TITLE
feat: Add Keycloak configuration for exporters and update Prometheus targets

### DIFF
--- a/configs/exporter_exporter/mods_available/auth/keycloak.yaml
+++ b/configs/exporter_exporter/mods_available/auth/keycloak.yaml
@@ -1,0 +1,4 @@
+method: http
+http:
+  address: host.docker.internal
+  port: 5602

--- a/configs/exporter_exporter/ovh-docker-staging/keycloak.yaml
+++ b/configs/exporter_exporter/ovh-docker-staging/keycloak.yaml
@@ -1,0 +1,1 @@
+../mods_available/auth/keycloak.yaml

--- a/configs/exporter_exporter/scaleway-docker-prod/keycloak.yaml
+++ b/configs/exporter_exporter/scaleway-docker-prod/keycloak.yaml
@@ -1,0 +1,1 @@
+../mods_available/auth/keycloak.yaml

--- a/configs/prometheus/config.yml
+++ b/configs/prometheus/config.yml
@@ -39,7 +39,7 @@ scrape_configs:
     static_configs:
       - targets:
           - cadvisor/infra/cadvisor
-          - auth/keycloak
+          - keycloak/auth/keycloak
           - node/infra/system
           - mongodb/shared/mongodb
           - postgres/shared/postgres
@@ -123,7 +123,7 @@ scrape_configs:
     static_configs: # see scaleway-exporters-exporters on how it works
       - targets:
           - cadvisor/infra/cadvisor
-          - auth/keycloak
+          - keycloak/auth/keycloak
           - node/infra/system
           - searchalicious_elasticsearch/searchalicious/elasticsearch
         labels:

--- a/configs/prometheus/config.yml
+++ b/configs/prometheus/config.yml
@@ -39,6 +39,7 @@ scrape_configs:
     static_configs:
       - targets:
           - cadvisor/infra/cadvisor
+          - auth/keycloak
           - node/infra/system
           - mongodb/shared/mongodb
           - postgres/shared/postgres
@@ -122,6 +123,7 @@ scrape_configs:
     static_configs: # see scaleway-exporters-exporters on how it works
       - targets:
           - cadvisor/infra/cadvisor
+          - auth/keycloak
           - node/infra/system
           - searchalicious_elasticsearch/searchalicious/elasticsearch
         labels:


### PR DESCRIPTION
### What

Keycloak exposes metrics on the management endpoint at `/metrics`, and we [do publish them for `openfoodfacts-auth`](https://github.com/openfoodfacts/openfoodfacts-auth/blob/5e8f4efab1ccebf8b57bdb9a9c307c0583a01a9d/Dockerfile#L49). I think it could be useful to capture the OIDC server's metrics, and figure our some alerts, if required.

I don't have any experience with OFF's exporter setup, and I cannot test this suggestion beforehand. Therefore, it's purely based on the existing Prometheus scrapers.

### Screenshot

- N/A

### Fixes bug(s)

- N/A

### Part of 

- N/A
