### PR TITLE
feat: Add PgHero to monitor off-query and shared-services databases

### DIFF
--- a/.env
+++ b/.env
@@ -37,3 +37,7 @@ EXPORTER_EXPORTER_CONFIG_DIR=dev
 
 # Prometheus
 PROMETHEUS_CONFIG_DIR=prometheus-dev
+
+COMMON_NET_NAME=off_shared_network
+PGHERO_CONFIG=./configs/pghero/pghero-dev.yml
+

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -112,6 +112,13 @@ jobs:
             echo "${{ secrets.MONITORING_BASIC_AUTH_PASSWORD }}" > configs/blackbox_exporter/secrets/monitoring_basic_auth.secret
             echo "${{ secrets.ELASTICSEARCH_BASIC_AUTH_PASSWORD }}" > configs/blackbox_exporter/secrets/elasticsearch_basic_auth.secret
 
+            # PgHero config. Note that underscores need to be url-encoded in the connection string
+            echo "databases:" > configs/pghero/pghero.yml
+            echo "  off-query:" >> configs/pghero/pghero.yml
+            echo "    url: ${{ secrets.OFF_QUERY_CONNECTION_STRING }}" >> configs/pghero/pghero.yml
+            echo "  shared-services:" >> configs/pghero/pghero.yml
+            echo "    url: ${{ secrets.SHARED_SERVICES_CONNECTION_STRING }}" >> configs/pghero/pghero.yml
+
       - name: Run envsubst on Prometheus configs
         uses: appleboy/ssh-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ secrets/
 
 .DS_Store
 configs/alertmanager/config.yml
+configs/pghero/pghero.yml
 
 # editors
 .vscode/

--- a/configs/pghero/pghero-dev.yml
+++ b/configs/pghero/pghero-dev.yml
@@ -1,0 +1,5 @@
+databases:
+  off-query:
+    url: postgres://productopener:productopener@query%5fpostgres%5fprimary:5432/query
+  shared-services:
+    url: postgres://postgres:SuperSecret123!@postgresql:5432/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,15 @@ services:
     networks:
       - monitoring
 
+  pghero:
+    image: ankane/pghero
+    volumes:
+      - "${PGHERO_CONFIG:-./configs/pghero/pghero.yml}:/app/config/pghero.yml:ro"
+    ports:
+      - "8203:8080"
+    networks:
+      - monitoring
+
 volumes:
   influxdb-data:
   grafana-data:

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -8,4 +8,12 @@ services:
   filebeat:
     networks:
       - monitoring
+  pghero:
+    networks:
+      - common_net
 
+
+networks:
+  common_net:
+    name: ${COMMON_NET_NAME}
+    external: true


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
Adds a PgHero container to monitor off-query and shared-services PostgreSQL databases.

TODO:
- configre SSH tunnel to access the databases
- add connection string secrets to reo